### PR TITLE
Lean on API validation for tower_inventory_source arg errors

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -192,7 +192,7 @@ class APIView(views.APIView):
                 response.data['detail'] += ' To establish a login session, visit /api/login/.'
                 logger.info(status_msg)
             else:
-                logger.warn(status_msg)
+                logger.warning(status_msg)
         response = super(APIView, self).finalize_response(request, response, *args, **kwargs)
         time_started = getattr(self, 'time_started', None)
         response['X-API-Node'] = settings.CLUSTER_HOST_ID

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2115,7 +2115,13 @@ class InventorySourceSerializer(UnifiedJobTemplateSerializer, InventorySourceOpt
         def get_field_from_model_or_attrs(fd):
             return attrs.get(fd, self.instance and getattr(self.instance, fd) or None)
 
-        if get_field_from_model_or_attrs('source') != 'scm':
+        if get_field_from_model_or_attrs('source') == 'scm':
+            if (('source' in attrs or 'source_project' in attrs) and
+                    get_field_from_model_or_attrs('source_project') is None):
+                raise serializers.ValidationError(
+                    {"source_project": _("Project required for scm type sources.")}
+                )
+        else:
             redundant_scm_fields = list(filter(
                 lambda x: attrs.get(x, None),
                 ['source_project', 'source_path', 'update_on_project_update']

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -126,6 +126,7 @@ class TowerModule(AnsibleModule):
         # If we have a specified  tower config, load it
         if self.params.get('tower_config_file'):
             try:
+                # TODO: warn if there are conflicts with other params
                 self.load_config(self.params.get('tower_config_file'))
             except ConfigFileException as cfe:
                 # Since we were told specifically to load this we want it to fail if we have an error

--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -179,164 +179,21 @@ def main():
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
-    # One question here is do we want to end up supporting this within the ansible module itself (i.e. required if, etc)
-    # Or do we want to let the API return issues with "this doesn't support that", etc.
-    #
-    # GUI OPTIONS:
-    # - - - - - - - manual:	file:	scm:	ec2:	gce	azure_rm	vmware	sat	cloudforms	openstack	rhv	tower	custom
-    # credential		?	?	o	o	r	r		r	r	r		r		r	r	o
-    # source_project		?	?	r	-	-	-		-	-	-		-		-	-	-
-    # source_path		?	?	r	-	-	-		-	-	-		-		-	-	-
-    # verbosity			?	?	o	o	o	o		o	o	o		o		o	o	o
-    # overwrite			?	?	o	o	o	o		o	o	o		o		o	o	o
-    # overwrite_vars		?	?	o	o	o	o		o	o	o		o		o	o	o
-    # update_on_launch		?	?	o	o	o	o		o	o	o		o		o	o	o
-    # update_on_project_launch	?	?	o	-	-	-		-	-	-		-		-	-	-
-    # source_regions		?	?	-	o	o	o		-	-	-		-		-	-	-
-    # instance_filters		?	?	-	o	-	-		o	-	-		-		-	o	-
-    # group_by			?	?	-	o	-	-		o	-	-		-		-	-	-
-    # source_vars*		?	?	-	o	-	o		o	o	o		o		-	-	-
-    # environmet vars*		?	?	o	-	-	-		-	-	-		-		-	-	o
-    # source_script		?	?	-	-	-	-		-	-	-		-		-	-	r
-    #
-    # * - source_vars are labeled environment_vars on project and custom sources
-
     # Create a module for ourselves
     module = TowerModule(argument_spec=argument_spec,
-                         supports_check_mode=True,
-                         required_if=[
-                             # We don't want to require source if state is present because
-                             # you might be doing an update to an existing source.
-                             # Later on in the code, we will do a test so that if state: present
-                             # and if we don't have an object, we must have source.
-                             ('source', 'scm', ['source_project', 'source_path']),
-                             ('source', 'gce', ['credential']),
-                             ('source', 'azure_rm', ['credential']),
-                             ('source', 'vmware', ['credential']),
-                             ('source', 'satellite6', ['credential']),
-                             ('source', 'cloudforms', ['credential']),
-                             ('source', 'openstack', ['credential']),
-                             ('source', 'rhv', ['credential']),
-                             ('source', 'tower', ['credential']),
-                             ('source', 'custom', ['source_script']),
-                         ],
-                         # This is provided by our module, it's not a core thing
-                         mutually_exclusive_if=[
-                             ('source', 'scm', ['source_regions',
-                                                'instance_filters',
-                                                'group_by',
-                                                'source_script'
-                                                ]),
-                             ('source', 'ec2', ['source_project',
-                                                'source_path',
-                                                'update_on_project_launch',
-                                                'source_script'
-                                                ]),
-                             ('source', 'gce', ['source_project',
-                                                'source_path',
-                                                'update_on_project_launch',
-                                                'instance_filters',
-                                                'group_by',
-                                                'source_vars',
-                                                'source_script'
-                                                ]),
-                             ('source', 'azure_rm', ['source_project',
-                                                     'source_path',
-                                                     'update_on_project_launch',
-                                                     'instance_filters',
-                                                     'group_by',
-                                                     'source_script'
-                                                     ]),
-                             ('source', 'vmware', ['source_project', 'source_path', 'update_on_project_launch', 'source_regions', 'source_script']),
-                             ('source', 'satellite6', ['source_project',
-                                                       'source_path',
-                                                       'update_on_project_launch',
-                                                       'source_regions',
-                                                       'instance_filters',
-                                                       'group_by',
-                                                       'source_script'
-                                                       ]),
-                             ('source', 'cloudforms', ['source_project',
-                                                       'source_path',
-                                                       'update_on_project_launch',
-                                                       'source_regions',
-                                                       'instance_filters',
-                                                       'group_by',
-                                                       'source_script'
-                                                       ]),
-                             ('source', 'openstack', ['source_project',
-                                                      'source_path',
-                                                      'update_on_project_launch',
-                                                      'source_regions',
-                                                      'instance_filters',
-                                                      'group_by',
-                                                      'source_script'
-                                                      ]),
-                             ('source', 'rhv', ['source_project',
-                                                'source_path',
-                                                'update_on_project_launch',
-                                                'source_regions',
-                                                'instance_filters',
-                                                'group_by',
-                                                'source_vars',
-                                                'source_script'
-                                                ]),
-                             ('source', 'tower', ['source_project',
-                                                  'source_path',
-                                                  'update_on_project_launch',
-                                                  'source_regions',
-                                                  'group_by',
-                                                  'source_vars',
-                                                  'source_script'
-                                                  ]),
-                             ('source', 'custom', ['source_project',
-                                                   'source_path',
-                                                   'update_on_project_launch',
-                                                   'source_regions',
-                                                   'instance_filters',
-                                                   'group_by'
-                                                   ]),
-                         ])
+                         supports_check_mode=True)
 
-    optional_vars = {}
     # Extract our parameters
     name = module.params.get('name')
     new_name = module.params.get('new_name')
-    optional_vars['description'] = module.params.get('description')
     inventory = module.params.get('inventory')
-    optional_vars['source'] = module.params.get('source')
-    optional_vars['source_path'] = module.params.get('source_path')
     source_script = module.params.get('source_script')
-    optional_vars['source_vars'] = module.params.get('source_vars')
     credential = module.params.get('credential')
-    optional_vars['source_regions'] = module.params.get('source_regions')
-    optional_vars['instance_filters'] = module.params.get('instance_filters')
-    optional_vars['group_by'] = module.params.get('group_by')
-    optional_vars['overwrite'] = module.params.get('overwrite')
-    optional_vars['overwrite_vars'] = module.params.get('overwrite_vars')
-    optional_vars['custom_virtualenv'] = module.params.get('custom_virtualenv')
-    optional_vars['timeout'] = module.params.get('timeout')
-    optional_vars['verbosity'] = module.params.get('verbosity')
-    optional_vars['update_on_launch'] = module.params.get('update_on_launch')
-    optional_vars['update_cache_timeout'] = module.params.get('update_cache_timeout')
     source_project = module.params.get('source_project')
-    optional_vars['update_on_project_update'] = module.params.get('update_on_project_update')
     state = module.params.get('state')
 
-    # Attempt to JSON encode source vars
-    if optional_vars['source_vars']:
-        optional_vars['source_vars'] = dumps(optional_vars['source_vars'])
-
-    # Attempt to look up the related items the user specified (these will fail the module if not found)
-    inventory_id = module.resolve_name_to_id('inventories', inventory)
-    if credential:
-        optional_vars['credential'] = module.resolve_name_to_id('credentials', credential)
-    if source_project:
-        optional_vars['source_project'] = module.resolve_name_to_id('projects', source_project)
-    if source_script:
-        optional_vars['source_script'] = module.resolve_name_to_id('inventory_scripts', source_script)
-
     # Attempt to look up inventory source based on the provided name and inventory ID
+    inventory_id = module.resolve_name_to_id('inventories', inventory)
     inventory_source = module.get_one('inventory_sources', **{
         'data': {
             'name': name,
@@ -344,19 +201,41 @@ def main():
         }
     })
 
-    # Sanity check on arguments
-    if state == 'present' and not inventory_source and not optional_vars['source']:
-        module.fail_json(msg="If creating a new inventory source, the source param must be present")
-
     # Create the data that gets sent for create and update
     inventory_source_fields = {
         'name': new_name if new_name else name,
         'inventory': inventory_id,
     }
+
+    # Attempt to look up the related items the user specified (these will fail the module if not found)
+    if credential:
+        inventory_source_fields['credential'] = module.resolve_name_to_id('credentials', credential)
+    if source_project:
+        inventory_source_fields['source_project'] = module.resolve_name_to_id('projects', source_project)
+    if source_script:
+        inventory_source_fields['source_script'] = module.resolve_name_to_id('inventory_scripts', source_script)
+
+    OPTIONAL_VARS = (
+        'description', 'source', 'source_path', 'source_vars',
+        'source_regions', 'instance_filters', 'group_by',
+        'overwrite', 'overwrite_vars', 'custom_virtualenv',
+        'timeout', 'verbosity', 'update_on_launch', 'update_cache_timeout',
+        'update_on_project_update'
+    )
+
     # Layer in all remaining optional information
-    for field_name in optional_vars:
-        if optional_vars[field_name]:
-            inventory_source_fields[field_name] = optional_vars[field_name]
+    for field_name in OPTIONAL_VARS:
+        field_val = module.params.get(field_name)
+        if field_val:
+            inventory_source_fields[field_name] = field_val
+
+    # Attempt to JSON encode source vars
+    if inventory_source_fields.get('source_vars', None):
+        inventory_source_fields['source_vars'] = dumps(inventory_source_fields['source_vars'])
+
+    # Sanity check on arguments
+    if state == 'present' and not inventory_source and not inventory_source_fields['source']:
+        module.fail_json(msg="If creating a new inventory source, the source param must be present")
 
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this

--- a/awx_collection/test/awx/test_inventory_source.py
+++ b/awx_collection/test/awx/test_inventory_source.py
@@ -10,25 +10,29 @@ from awx.main.models import Organization, Inventory, InventorySource, Project
 def base_inventory():
     org = Organization.objects.create(name='test-org')
     inv = Inventory.objects.create(name='test-inv', organization=org)
-    Project.objects.create(
-        name='test-proj',
-        organization=org,
-        scm_type='git',
-        scm_url='https://github.com/ansible/test-playbooks.git',
-    )
     return inv
 
 
+@pytest.fixture
+def project(base_inventory):
+    return Project.objects.create(
+        name='test-proj',
+        organization=base_inventory.organization,
+        scm_type='git',
+        scm_url='https://github.com/ansible/test-playbooks.git',
+    )
+
+
 @pytest.mark.django_db
-def test_inventory_source_create(run_module, admin_user, base_inventory):
+def test_inventory_source_create(run_module, admin_user, base_inventory, project):
     source_path = '/var/lib/awx/example_source_path/'
     result = run_module('tower_inventory_source', dict(
         name='foo',
-        inventory='test-inv',
+        inventory=base_inventory.name,
         state='present',
         source='scm',
         source_path=source_path,
-        source_project='test-proj'
+        source_project=project.name
     ), admin_user)
     assert result.pop('changed', None), result
 
@@ -46,6 +50,7 @@ def test_create_inventory_source_implied_org(run_module, admin_user):
     org = Organization.objects.create(name='test-org')
     inv = Inventory.objects.create(name='test-inv', organization=org)
 
+    # Credential is not required for ec2 source, because of IAM roles
     result = run_module('tower_inventory_source', dict(
         name='Test Inventory Source',
         inventory='test-inv',
@@ -92,16 +97,16 @@ def test_create_inventory_source_multiple_orgs(run_module, admin_user):
 
 
 @pytest.mark.django_db
-def test_create_inventory_source_with_venv(run_module, admin_user, base_inventory, mocker):
+def test_create_inventory_source_with_venv(run_module, admin_user, base_inventory, mocker, project):
     path = '/var/lib/awx/venv/custom-venv/foobar13489435/'
     source_path = '/var/lib/awx/example_source_path/'
     with mocker.patch('awx.main.models.mixins.get_custom_venv_choices', return_value=[path]):
         result = run_module('tower_inventory_source', dict(
             name='foo',
-            inventory='test-inv',
+            inventory=base_inventory.name,
             state='present',
             source='scm',
-            source_project='test-proj',
+            source_project=project.name,
             custom_virtualenv=path,
             source_path=source_path
         ), admin_user)
@@ -115,7 +120,7 @@ def test_create_inventory_source_with_venv(run_module, admin_user, base_inventor
 
 
 @pytest.mark.django_db
-def test_custom_venv_no_op(run_module, admin_user, base_inventory, mocker):
+def test_custom_venv_no_op(run_module, admin_user, base_inventory, mocker, project):
     """If the inventory source is modified, then it should not blank fields
     unrelated to the params that the user passed.
     This enforces assumptions about the behavior of the AnsibleModule
@@ -125,7 +130,7 @@ def test_custom_venv_no_op(run_module, admin_user, base_inventory, mocker):
     inv_src = InventorySource.objects.create(
         name='foo',
         inventory=base_inventory,
-        source_project=Project.objects.get(name='test-proj'),
+        source_project=project,
         source='scm',
         custom_virtualenv='/venv/foobar/'
     )
@@ -134,13 +139,93 @@ def test_custom_venv_no_op(run_module, admin_user, base_inventory, mocker):
         result = run_module('tower_inventory_source', dict(
             name='foo',
             description='this is the changed description',
-            inventory='test-inv',
+            inventory=base_inventory.name,
             source='scm',  # is required, but behavior is arguable
             state='present',
-            source_project='test-proj',
+            source_project=project.name,
             source_path=source_path
         ), admin_user)
     assert result.pop('changed', None), result
     inv_src.refresh_from_db()
     assert inv_src.custom_virtualenv == '/venv/foobar/'
     assert inv_src.description == 'this is the changed description'
+
+
+# Tests related to source-specific parameters
+#
+# We want to let the API return issues with "this doesn't support that", etc.
+#
+# GUI OPTIONS:
+# - - - - - - - manual:	file:	scm:	ec2:	gce	azure_rm	vmware	sat	cloudforms	openstack	rhv	tower	custom
+# credential		?	?	o	o	r	r		r	r	r		r		r	r	o
+# source_project	?	?	r	-	-	-		-	-	-		-		-	-	-
+# source_path		?	?	r	-	-	-		-	-	-		-		-	-	-
+# verbosity			?	?	o	o	o	o		o	o	o		o		o	o	o
+# overwrite			?	?	o	o	o	o		o	o	o		o		o	o	o
+# overwrite_vars	?	?	o	o	o	o		o	o	o		o		o	o	o
+# update_on_launch	?	?	o	o	o	o		o	o	o		o		o	o	o
+# UoPL          	?	?	o	-	-	-		-	-	-		-		-	-	-
+# source_regions	?	?	-	o	o	o		-	-	-		-		-	-	-
+# instance_filters	?	?	-	o	-	-		o	-	-		-		-	o	-
+# group_by			?	?	-	o	-	-		o	-	-		-		-	-	-
+# source_vars*		?	?	-	o	-	o		o	o	o		o		-	-	-
+# environmet vars*	?	?	o	-	-	-		-	-	-		-		-	-	o
+# source_script		?	?	-	-	-	-		-	-	-		-		-	-	r
+#
+# UoPL - update_on_project_launch
+# * - source_vars are labeled environment_vars on project and custom sources
+
+
+@pytest.mark.django_db
+def test_missing_required_credential(run_module, admin_user, base_inventory):
+    result = run_module('tower_inventory_source', dict(
+        name='Test Azure Source',
+        inventory=base_inventory.name,
+        source='azure_rm',
+        state='present'
+    ), admin_user)
+    assert result.pop('failed', None) is True, result
+
+    assert 'Credential is required for a cloud source' in result.get('msg', '')
+
+
+@pytest.mark.django_db
+def test_source_project_not_for_cloud(run_module, admin_user, base_inventory, project):
+    result = run_module('tower_inventory_source', dict(
+        name='Test ec2 Inventory Source',
+        inventory=base_inventory.name,
+        source='ec2',
+        state='present',
+        source_project=project.name
+    ), admin_user)
+    assert result.pop('failed', None) is True, result
+
+    assert 'Cannot set source_project if not SCM type' in result.get('msg', '')
+
+
+@pytest.mark.django_db
+def test_source_path_not_for_cloud(run_module, admin_user, base_inventory):
+    result = run_module('tower_inventory_source', dict(
+        name='Test ec2 Inventory Source',
+        inventory=base_inventory.name,
+        source='ec2',
+        state='present',
+        source_path='where/am/I'
+    ), admin_user)
+    assert result.pop('failed', None) is True, result
+
+    assert 'Cannot set source_path if not SCM type' in result.get('msg', '')
+
+
+@pytest.mark.django_db
+def test_scm_source_needs_project(run_module, admin_user, base_inventory):
+    result = run_module('tower_inventory_source', dict(
+        name='SCM inventory without project',
+        inventory=base_inventory.name,
+        state='present',
+        source='scm',
+        source_path='/var/lib/awx/example_source_path/'
+    ), admin_user)
+    assert result.pop('failed', None), result
+
+    assert 'Project required for scm type sources' in result.get('msg', '')


### PR DESCRIPTION
The missing source_project is the one case we discussed.

There is a weaker case that validation errors should be displayed in some other cases (regions, group_by, etc.). It's not that I'm against those, they are valid entries for AWX API issues. But I firmly believe that the module is the wrong place for this. Following from the experience from the AWX CLI, I am very strongly arguing for mutual-field validation cases to be handled by API code.