### PR TITLE
Unit testing of tower_schedule

### DIFF
--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -15,7 +15,7 @@ from requests.models import Response
 import pytest
 
 from awx.main.tests.functional.conftest import _request
-from awx.main.models import Organization, Project, Inventory, Credential, CredentialType
+from awx.main.models import Organization, Project, Inventory, JobTemplate, Credential, CredentialType
 
 try:
     import tower_cli  # noqa
@@ -213,6 +213,16 @@ def inventory(organization):
     return Inventory.objects.create(
         name='test-inv',
         organization=organization
+    )
+
+
+@pytest.fixture
+def job_template(project, inventory):
+    return JobTemplate.objects.create(
+        name='test-jt',
+        project=project,
+        inventory=inventory,
+        playbook='helloworld.yml'
     )
 
 

--- a/awx_collection/test/awx/test_schedule.py
+++ b/awx_collection/test/awx/test_schedule.py
@@ -1,0 +1,101 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleError
+
+from awx.main.models import Schedule
+
+
+@pytest.mark.django_db
+def test_create_schedule(run_module, job_template, admin_user):
+    my_rrule = 'DTSTART;TZID=Zulu:20200416T034507 RRULE:FREQ=MONTHLY;INTERVAL=1'
+    result = run_module('tower_schedule', {
+        'name': 'foo_schedule',
+        'unified_job_template': job_template.name,
+        'rrule': my_rrule
+    }, admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    schedule = Schedule.objects.filter(name='foo_schedule').first()
+
+    assert result['id'] == schedule.id
+    assert result['changed']
+
+    assert schedule.rrule == my_rrule
+
+
+@pytest.mark.parametrize("freq, kwargs, expect", [
+    # Test with a valid start date (no time) (also tests none frequency and count)
+    ('none', {'start_date': '2020-04-16'}, 'DTSTART;TZID=America/New_York:20200416T000000 RRULE:FREQ=DAILY;COUNT=1;INTERVAL=1'),
+    # Test with a valid start date and time
+    ('none', {'start_date': '2020-04-16 03:45:07'}, 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=DAILY;COUNT=1;INTERVAL=1'),
+    # Test end_on as count (also integration test)
+    ('minute', {'start_date': '2020-4-16 03:45:07', 'end_on': '2'}, 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MINUTELY;COUNT=2;INTERVAL=1'),
+    # Test end_on as date
+    ('minute', {'start_date': '2020-4-16 03:45:07', 'end_on': '2020-4-17 03:45:07'},
+        'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MINUTELY;UNTIL=20200417T034507;INTERVAL=1'),
+    # Test on_days as a single day
+    ('week', {'start_date': '2020-4-16 03:45:07', 'on_days': 'saturday'},
+        'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=WEEKLY;BYDAY=SA;INTERVAL=1'),
+    # Test on_days as multiple days (with some whitespaces)
+    ('week', {'start_date': '2020-4-16 03:45:07', 'on_days': 'saturday,monday , friday'},
+        'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=WEEKLY;BYDAY=MO,FR,SA;INTERVAL=1'),
+    # Test valid month_day_number
+    ('month', {'start_date': '2020-4-16 03:45:07', 'month_day_number': '18'},
+        'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MONTHLY;BYMONTHDAY=18;INTERVAL=1'),
+    # Test a valid on_the
+    ('month', {'start_date': '2020-4-16 03:45:07', 'on_the': 'second sunday'},
+        'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MONTHLY;BYSETPOS=2;BYDAY=SU;INTERVAL=1'),
+    # Test an valid timezone
+    ('month', {'start_date': '2020-4-16 03:45:07', 'timezone': 'Zulu'},
+        'DTSTART;TZID=Zulu:20200416T034507 RRULE:FREQ=MONTHLY;INTERVAL=1'),
+])
+def test_rrule_lookup_plugin(collection_import, freq, kwargs, expect):
+    LookupModule = collection_import('plugins.lookup.tower_schedule_rrule').LookupModule
+    assert LookupModule.get_rrule(freq, kwargs) == expect
+
+
+@pytest.mark.parametrize("freq", ('none', 'minute', 'hour', 'day', 'week', 'month'))
+def test_empty_schedule_rrule(collection_import, freq):
+    LookupModule = collection_import('plugins.lookup.tower_schedule_rrule').LookupModule
+    if freq == 'day':
+        pfreq = 'DAILY'
+    elif freq == 'none':
+        pfreq = 'DAILY;COUNT=1'
+    else:
+        pfreq = freq.upper() + 'LY'
+    assert LookupModule.get_rrule(freq, {}).endswith(' RRULE:FREQ={0};INTERVAL=1'.format(pfreq))
+
+
+@pytest.mark.parametrize("freq, kwargs, msg", [
+    # Test end_on as junk
+    ('minute', {'start_date': '2020-4-16 03:45:07', 'end_on': 'junk'},
+        'Parameter end_on must either be an integer or in the format YYYY-MM-DD'),
+    # Test on_days as junk
+    ('week', {'start_date': '2020-4-16 03:45:07', 'on_days': 'junk'},
+        'Parameter on_days must only contain values monday, tuesday, wednesday, thursday, friday, saturday, sunday'),
+    # Test combo of both month_day_number and on_the
+    ('month', dict(start_date='2020-4-16 03:45:07', on_the='something', month_day_number='else'),
+        "Month based frquencies can have month_day_number or on_the but not both"),
+    # Test month_day_number as not an integer
+    ('month', dict(start_date='2020-4-16 03:45:07', month_day_number='junk'), "month_day_number must be between 1 and 31"),
+    # Test month_day_number < 1
+    ('month', dict(start_date='2020-4-16 03:45:07', month_day_number='0'), "month_day_number must be between 1 and 31"),
+    # Test month_day_number > 31
+    ('month', dict(start_date='2020-4-16 03:45:07', month_day_number='32'), "month_day_number must be between 1 and 31"),
+    # Test on_the as junk
+    ('month', dict(start_date='2020-4-16 03:45:07', on_the='junk'), "on_the parameter must be two space seperated words"),
+    # Test on_the with invalid occurance
+    ('month', dict(start_date='2020-4-16 03:45:07', on_the='junk wednesday'), "The first string of the on_the parameter is not valid"),
+    # Test on_the with invalid weekday
+    ('month', dict(start_date='2020-4-16 03:45:07', on_the='second junk'), "Weekday portion of on_the parameter is not valid"),
+    # Test an invalid timezone
+    ('month', dict(start_date='2020-4-16 03:45:07', timezone='junk'), 'Timezone parameter is not valid'),
+])
+def test_rrule_lookup_plugin_failure(collection_import, freq, kwargs, msg):
+    LookupModule = collection_import('plugins.lookup.tower_schedule_rrule').LookupModule
+    with pytest.raises(AnsibleError) as e:
+        assert LookupModule.get_rrule(freq, kwargs)
+    assert msg in str(e.value)

--- a/awx_collection/tests/integration/targets/tower_schedule_rrule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_schedule_rrule/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Test too many params
+- name: Test too many params (failure from validation of terms)
   debug:
     msg: "{{ query('awx.awx.tower_schedule_rrule', 'none', 'weekly', start_date='2020-4-16 03:45:07') }}"
   ignore_errors: true
@@ -10,7 +10,7 @@
       - result is failed
       - "'You may only pass one schedule type in at a time' in result.msg"
 
-- name: Test invalid frequency
+- name: Test invalid frequency (failure from validation of term)
   debug:
     msg: "{{ query('awx.awx.tower_schedule_rrule', 'john', start_date='2020-4-16 03:45:07') }}"
   ignore_errors: true
@@ -21,7 +21,7 @@
       - result is failed
       - "'Frequency of john is invalid' in result.msg"
 
-- name: Test an invalid start date
+- name: Test an invalid start date (generic failure case from get_rrule)
   debug:
     msg: "{{ query('awx.awx.tower_schedule_rrule', 'none', start_date='invalid') }}"
   ignore_errors: true
@@ -32,221 +32,11 @@
       - result is failed
       - "'Parameter start_date must be in the format YYYY-MM-DD' in result.msg"
 
-- name: Test with a valid start date (no time) (also tests none frequency and count)
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'none', start_date='2020-04-16') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T000000 RRULE:FREQ=DAILY;COUNT=1;INTERVAL=1'
-
-- name: Test with a valid start date and time
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'none', start_date='2020-04-16 03:45:07') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=DAILY;COUNT=1;INTERVAL=1'
-
-- name: Test end_on as count
+- name: Test end_on as count (generic success case)
   debug:
     msg: "{{ query('awx.awx.tower_schedule_rrule', 'minute', start_date='2020-4-16 03:45:07', end_on='2') }}"
-  ignore_errors: true
   register: result
 
 - assert:
     that:
-      - result is not failed
       - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MINUTELY;COUNT=2;INTERVAL=1'
-
-- name: Test end_on as date
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'minute', start_date='2020-4-16 03:45:07', end_on='2020-4-17 03:45:07') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MINUTELY;UNTIL=20200417T034507;INTERVAL=1'
-
-- name: Test end_on as junk
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'minute', start_date='2020-4-16 03:45:07', end_on='junk') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"Parameter end_on must either be an integer or in the format YYYY-MM-DD" in result.msg'
-
-- name: Test on_days as junk
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'week', start_date='2020-4-16 03:45:07', on_days='junk') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"Parameter on_days must only contain values monday, tuesday, wednesday, thursday, friday, saturday, sunday" in result.msg'
-
-- name: Test on_days as a single day
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'week', start_date='2020-4-16 03:45:07', on_days='saturday') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=WEEKLY;BYDAY=SA;INTERVAL=1'
-
-- name: Test on_days as multiple days (with some whitespaces)
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'week', start_date='2020-4-16 03:45:07', on_days='saturday,monday , friday') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=WEEKLY;BYDAY=MO,FR,SA;INTERVAL=1'
-
-- name: Test combo of both month_day_number and on_the
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', on_the='something', month_day_number='else') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"Month based frquencies can have month_day_number or on_the but not both" in result.msg'
-
-- name: Test month_day_number as not an integer
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', month_day_number='junk') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"month_day_number must be between 1 and 31" in result.msg'
-
-- name: Test month_day_number < 1
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', month_day_number='0') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"month_day_number must be between 1 and 31" in result.msg'
-
-- name: Test month_day_number > 31
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', month_day_number='32') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"month_day_number must be between 1 and 31" in result.msg'
-
-- name: Test valid month_day_number
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', month_day_number='18') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MONTHLY;BYMONTHDAY=18;INTERVAL=1'
-
-- name: Test on_the as junk
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', on_the='junk') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"on_the parameter must be two space seperated words" in result.msg'
-
-- name: Test on_the with invalid occurance
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', on_the='junk wednesday') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"The first string of the on_the parameter is not valid" in result.msg'
-
-- name: Test on_the with invalid weekday
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', on_the='second junk') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - '"Weekday portion of on_the parameter is not valid" in result.msg'
-
-- name: Test a valid on_the
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', on_the='second sunday') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MONTHLY;BYSETPOS=2;BYDAY=SU;INTERVAL=1'
-
-- name: Test an invalid timezone
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', timezone='junk') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - "'Timezone parameter is not valid' in result.msg"
-
-- name: Test an valid timezone
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month', start_date='2020-4-16 03:45:07', timezone='Zulu') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed
-      - result.msg == 'DTSTART;TZID=Zulu:20200416T034507 RRULE:FREQ=MONTHLY;INTERVAL=1'
-
-- name: Test an empty schedule
-  debug:
-    msg: "{{ query('awx.awx.tower_schedule_rrule', 'month') }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is not failed


### PR DESCRIPTION
I wanted to make these more readable, also wanted to have a direct line to the code and the ORM in case we wanted it for any reason later on.

This doesn't eliminate the need for integration testing - I am keeping a few cases shared between the two. We _should_ test errors in integration tests, to capture the full cycle. It's just diving deep down into the corner cases of syntax where we should use unit tests to efficiently handle it.