### PR TITLE
Add WorkflowJob.instance_groups and distinguish from char_prompts

### DIFF
--- a/awx/main/migrations/0167_jt_prompt_everything_on_launch.py
+++ b/awx/main/migrations/0167_jt_prompt_everything_on_launch.py
@@ -214,4 +214,24 @@ class Migration(migrations.Migration):
                 to='main.InstanceGroup',
             ),
         ),
+        migrations.CreateModel(
+            name='WorkflowJobInstanceGroupMembership',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('position', models.PositiveIntegerField(db_index=True, default=None, null=True)),
+                ('instancegroup', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.instancegroup')),
+                ('workflowjobnode', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.workflowjob')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='workflowjob',
+            name='instance_groups',
+            field=awx.main.fields.OrderedManyToManyField(
+                blank=True,
+                editable=False,
+                related_name='workflow_job_instance_groups',
+                through='main.WorkflowJobInstanceGroupMembership',
+                to='main.InstanceGroup',
+            ),
+        ),
     ]

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -489,3 +489,14 @@ class WorkflowJobNodeBaseInstanceGroupMembership(models.Model):
         default=None,
         db_index=True,
     )
+
+
+class WorkflowJobInstanceGroupMembership(models.Model):
+
+    workflowjobnode = models.ForeignKey('WorkflowJob', on_delete=models.CASCADE)
+    instancegroup = models.ForeignKey('InstanceGroup', on_delete=models.CASCADE)
+    position = models.PositiveIntegerField(
+        null=True,
+        default=None,
+        db_index=True,
+    )

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -942,6 +942,28 @@ class LaunchTimeConfigBase(BaseModel):
     # This is a solution to the nullable CharField problem, specific to prompting
     char_prompts = JSONBlob(default=dict, blank=True)
 
+    # Define fields that are not really fields, but alias to char_prompts lookups
+    limit = NullablePromptPseudoField('limit')
+    scm_branch = NullablePromptPseudoField('scm_branch')
+    job_tags = NullablePromptPseudoField('job_tags')
+    skip_tags = NullablePromptPseudoField('skip_tags')
+    diff_mode = NullablePromptPseudoField('diff_mode')
+    job_type = NullablePromptPseudoField('job_type')
+    verbosity = NullablePromptPseudoField('verbosity')
+    forks = NullablePromptPseudoField('forks')
+    job_slice_count = NullablePromptPseudoField('job_slice_count')
+    timeout = NullablePromptPseudoField('timeout')
+
+    # NOTE: additional fields are assumed to exist but must be defined in subclasses
+    # due to technical limitations
+    SUBCLASS_FIELDS = (
+        'instance_groups',  # needs a through model defined
+        'extra_vars',  # alternates between extra_vars and extra_data
+        'credentials',  # already a unified job and unified JT field
+        'labels',  # already a unified job and unified JT field
+        'execution_environment',  # already a unified job and unified JT field
+    )
+
     def prompts_dict(self, display=False):
         data = {}
         # Some types may have different prompts, but always subset of JT prompts
@@ -976,15 +998,6 @@ class LaunchTimeConfigBase(BaseModel):
         return data
 
 
-for field_name in JobTemplate.get_ask_mapping().keys():
-    if field_name == 'extra_vars':
-        continue
-    try:
-        LaunchTimeConfigBase._meta.get_field(field_name)
-    except FieldDoesNotExist:
-        setattr(LaunchTimeConfigBase, field_name, NullablePromptPseudoField(field_name))
-
-
 class LaunchTimeConfig(LaunchTimeConfigBase):
     """
     Common model for all objects that save details of a saved launch config
@@ -1003,12 +1016,9 @@ class LaunchTimeConfig(LaunchTimeConfigBase):
             blank=True,
         )
     )
-    # Credentials needed for non-unified job / unified JT models
+    # Fields needed for non-unified job / unified JT models, because they are defined on unified models
     credentials = models.ManyToManyField('Credential', related_name='%(class)ss')
-
-    # Labels needed for non-unified job / unified JT models
     labels = models.ManyToManyField('Label', related_name='%(class)s_labels')
-
     execution_environment = models.ForeignKey(
         'ExecutionEnvironment', null=True, blank=True, default=None, on_delete=polymorphic.SET_NULL, related_name='%(class)s_as_prompt'
     )

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -384,6 +384,10 @@ class WorkflowJobOptions(LaunchTimeConfigBase):
             )
         )
     )
+    # Workflow jobs are used for sliced jobs, and thus, must be a conduit for any JT prompts
+    instance_groups = OrderedManyToManyField(
+        'InstanceGroup', related_name='workflow_job_instance_groups', blank=True, editable=False, through='WorkflowJobInstanceGroupMembership'
+    )
     allow_simultaneous = models.BooleanField(default=False)
 
     extra_vars_dict = VarsDictProperty('extra_vars', True)


### PR DESCRIPTION
##### SUMMARY
Initial draft of fix for server error when combining prompting for slice count & instance groups.

The `instance_groups` field was getting initialized as a `NullablePromptPseudoField`, which is no-no-no-no-no kind of behavior. For that to even be _possible_ some serious sins have to be committed.

Here, I back out some of the meta-programming I did years ago. There is no better proof of the un-maintainability of a pattern than the failure of that pattern to be maintained.

Removing the satanic `setattr` does not directly resolve the error, but makes it obvious what that error was, which is that the slicing patterns had created an expectation that `WorkflowJob.instance_groups` existed as an ordered m2m, and it did not.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

