### PR TITLE
Changes to continue respecting idpotence of unordered associations

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -673,20 +673,26 @@ class ControllerAPIModule(ControllerModule):
         response = self.get_all_endpoint(association_endpoint)
         existing_associated_ids = [association['id'] for association in response['json']['results']]
 
-        # If the current associations match the desired associations then we can just return
-        if existing_associated_ids == new_association_list:
-            return
+        # Some associations can be ordered (like galaxy credentials)
+        if association_endpoint.strip('/').split('/')[-1] in ('instance_groups', 'galaxy_credentials'):
+            if existing_associated_ids == new_association_list:
+                return  # If the current associations EXACTLY match the desired associations then we can return
+            removal_list = existing_associated_ids  # because of ordering, we have to remove everything
+            addition_list = new_association_list  # re-add everything back in-order
+        else:
+            if set(existing_associated_ids) == set(new_association_list):
+                return
+            removal_list = set(existing_associated_ids) - set(new_association_list)
+            addition_list = set(new_association_list) - set(existing_associated_ids)
 
-        # Some associations can be ordered (like galaxy credentials), because of this we have to remove everything to re-add in order
-        for an_id in existing_associated_ids:
+        for an_id in removal_list:
             response = self.post_endpoint(association_endpoint, **{'data': {'id': int(an_id), 'disassociate': True}})
             if response['status_code'] == 204:
                 self.json_output['changed'] = True
             else:
                 self.fail_json(msg="Failed to disassociate item {0}".format(response['json'].get('detail', response['json'])))
 
-        # Now we will add everything back in the received order
-        for an_id in new_association_list:
+        for an_id in addition_list:
             response = self.post_endpoint(association_endpoint, **{'data': {'id': int(an_id)}})
             if response['status_code'] == 204:
                 self.json_output['changed'] = True


### PR DESCRIPTION
##### SUMMARY
This makes changes to the module_utils so that we will treat ordered associations differently from unordered associations.

The critical assertion that I'm most pig-headed about is

```python
    # shuffling the labels should not result in any change
    random.shuffle(labels)
    result = run_module('job_template', dict(name=jt.name, playbook='helloworld.yml', labels=[l.name for l in labels]), admin_user)
    assert not result.get('failed', False), result.get('msg', result)
    assert result['changed'] is False
```

We don't have any guarantees of ordering on the backend. So we need to treat shuffled lists as the same. This is something that was failing before these changes, I feel like our testing on this was pretty light before.

It would be very disruptive to users of the collection if the next release started removing and adding back all the associations. Yeah, it would work, but would be very slow, do irrelevant things, be non-atomic, get changed status wrong, mess up modified_by type time stamps, spam the activity stream, etc.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

